### PR TITLE
It’s a ponyfill!

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Underneath it uses real string property names which can easily be retrieved, how
 
 ### Usage
 
-If you'd like to use native version when it exists and fallback to polyfill if it doesn't (but without implementing `Symbol` on global scope), do:
+It’s safest to use *es6-symbol* as a [ponyfill](http://kikobeats.com/polyfill-ponyfill-and-prollyfill/) – a polyfill which doesn’t touch global objects:
 
 ```javascript
 var Symbol = require('es6-symbol');
 ```
 
-If you want to make sure your environment implements `Symbol`, do:
+If you want to make sure your environment implements `Symbol` globally, do:
 
 ```javascript
 require('es6-symbol/implement');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "property",
     "es6",
     "ecmascript",
-    "harmony"
+    "harmony",
+    "ponyfill",
+    "polyfill"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
“ponyfill” is the current buzzword for what `require('es6-module')` is. The term seems to have been coined together by @sindresorhus.

![pony](http://www.bestcoloringpagesforkids.com/wp-content/uploads/2013/05/My-Little-Pony-Coloring-Pages.jpg)

More reading: <http://kikobeats.com/polyfill-ponyfill-and-prollyfill/>.